### PR TITLE
Added into_inner() method to UpgradedResponse

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,6 +193,11 @@ impl UpgradeResponse {
 
         Ok(WebSocket { inner, protocol })
     }
+
+    /// Consumes the response and returns the inner [`reqwest::Response`].
+    pub async fn into_inner(self) -> reqwest::Response {
+        self.inner.response
+    }
 }
 
 /// A websocket connection

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,7 +195,7 @@ impl UpgradeResponse {
     }
 
     /// Consumes the response and returns the inner [`reqwest::Response`].
-    pub async fn into_inner(self) -> reqwest::Response {
+    pub fn into_inner(self) -> reqwest::Response {
         self.inner.response
     }
 }


### PR DESCRIPTION
This allows getting owned `reqwest::Response` from `UpgradedResponse`.

Why?

Currently, it's impossible to get response text in case of a non-200 status (e.g. on 404 or 400 due to invalid query params or path params), when the server returns an error response instead of upgrading a socket.

The example usage:

```rust
// create a GET request, upgrade it and send it.
let response = Client::default()
    .get("wss://echo.websocket.org/")
    .upgrade() // <-- prepares the websocket upgrade.
    .send()
    .await?;

if !response.status.is_informational() {
   return Err(response.into_inner().text().await.unwrap())
}

// turn the response into a websocket stream
let mut websocket = response.into_websocket().await?;

```