### PR TITLE
Fix some wasm issues, and add the `sink` feature to futures-util

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ categories = [
 ]
 
 [dependencies]
-futures-util = { version = "0.3", default-features = false }
+futures-util = { version = "0.3", default-features = false, features = [ "sink" ] }
 reqwest = { version = "0.12", default-features = false }
 thiserror = "1"
 tokio-util = { version = "0.7", default-features = false, features = ["compat"] }


### PR DESCRIPTION
- the new `UpgradeResponse::into_inner` method can't work on wasm, so wrap it in a `cfg(not(target_arch = "wasm32"))`
- the `http1_only` method does not exist on reqwest's ClientBuilder in wasm mode, so write a utility function that only does that in non-wasm32 mode
- reqwest-websocket unconditionally relies on the `sink` feature of `futures-util`, so declare that it needs that feature in Cargo.toml.


These changes have allowed reqwest-websocket to compile as a dependency of my own project, but for some reason running `cargo check --target wasm32-unknown-unknown` on reqwest-websocket directly fails with some very confusing error messages. I think that to ensure reqwest-websocket continues working with wasm32 in the future, this will need to be addressed and added to CI, but I haven't been able to figure out the problem yet.