### PR TITLE
Fix panic on empty close frame

### DIFF
--- a/src/native.rs
+++ b/src/native.rs
@@ -270,9 +270,11 @@ impl TryFrom<tungstenite::Message> for Message {
                 code: code.into(),
                 reason: reason.into_owned(),
             }),
-            tungstenite::Message::Close(None) | tungstenite::Message::Frame(_) => {
-                Err(FromTungsteniteMessageError { original: value })
-            }
+            tungstenite::Message::Close(None) => Ok(Self::Close {
+                code: CloseCode::default(),
+                reason: "".to_owned(),
+            }),
+            tungstenite::Message::Frame(_) => Err(FromTungsteniteMessageError { original: value }),
         }
     }
 }


### PR DESCRIPTION
Fixes #24 

This returns a `Message::Close { code: CloseCode::default(), reason: "".to_owned() }` when a `tungstenite::Message::Close(None)` is received.

We should probably copy the design from tungstenite and make the `Close` variant take an `Option`, but we also need to consider how web-sys does things.