### PR TITLE
Update both tungstenite and async-tungstenite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,9 +31,9 @@ serde = { version = "1.0", default-features = false, optional = true }
 serde_json = { version = "1.0", default-features = false, optional = true, features = ["alloc"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-async-tungstenite = { version = "0.27", default-features = false }
+async-tungstenite = { version = "0.28", default-features = false }
 tokio-util = { version = "0.7", default-features = false, features = ["compat"] }
-tungstenite = { version = "0.23", default-features = false, features = ["handshake"] }
+tungstenite = { version = "0.24", default-features = false, features = ["handshake"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { version = "0.3", features = ["WebSocket", "CloseEvent", "ErrorEvent", "Event", "MessageEvent", "BinaryType"] }


### PR DESCRIPTION
Dependabot has already opened individual PRs, but for CI to pass both need to be bumped at the same time.