### PR TITLE
Fix #32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,8 @@ serde = { version = "1.0", default-features = false, optional = true }
 serde_json = { version = "1.0", default-features = false, optional = true, features = ["alloc"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-async-tungstenite = { version = "0.28", default-features = false }
+#async-tungstenite = { version = "0.28", default-features = false, features = ["futures-03-sink"] }
+async-tungstenite = { git = "https://github.com/jgraef/async-tungstenite.git", branch = "switch/fix-arc-waker", default-features = false, features = ["futures-03-sink"] }
 tokio-util = { version = "0.7", default-features = false, features = ["compat"] }
 tungstenite = { version = "0.24", default-features = false, features = ["handshake"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,7 @@ serde = { version = "1.0", default-features = false, optional = true }
 serde_json = { version = "1.0", default-features = false, optional = true, features = ["alloc"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-#async-tungstenite = { version = "0.28", default-features = false, features = ["futures-03-sink"] }
-async-tungstenite = { git = "https://github.com/jgraef/async-tungstenite.git", branch = "switch/fix-arc-waker", default-features = false, features = ["futures-03-sink"] }
+async-tungstenite = { version = "0.28.2", default-features = false, features = ["futures-03-sink"] }
 tokio-util = { version = "0.7", default-features = false, features = ["compat"] }
 tungstenite = { version = "0.24", default-features = false, features = ["handshake"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 json = ["dep:serde", "dep:serde_json"]
 
 [dependencies]
-futures-util = { version = "0.3", default-features = false, features = ["sink"] }
+# pin version, see https://github.com/jgraef/reqwest-websocket/pull/33
+futures-util = { version = ">=0.3.31", default-features = false, features = ["sink"] }
 reqwest = { version = "0.12", default-features = false }
 thiserror = "2"
 tracing = "0.1"


### PR DESCRIPTION
Fixes #32 

1. Added `futures-03-sink` to `async-tungstenite`'s features.
2. Fixed a bug in `async-tungstenite` (see [PR][1]) and changed the dependency to use that PR for now

I'll wait with merging this to see if we can get rid of the git dependency.

[1]: https://github.com/sdroege/async-tungstenite/pull/147