### PR TITLE
Added a reqwest-middleware feature to handle reqwest client that uses middlewares

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,15 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 json = ["dep:serde", "dep:serde_json"]
+middleware = ["reqwest-middleware"]
 
 [dependencies]
 # pin version, see https://github.com/jgraef/reqwest-websocket/pull/33
 futures-util = { version = ">=0.3.31", default-features = false, features = ["sink"] }
 reqwest = { version = "0.12", default-features = false }
+reqwest-middleware = { version = "0.4.2", default-features = false, optional = true }
 thiserror = "2"
+anyhow = "1.0.99"
 tracing = "0.1"
 serde = { version = "1.0", default-features = false, optional = true }
 serde_json = { version = "1.0", default-features = false, optional = true, features = ["alloc"] }
@@ -39,7 +42,7 @@ tungstenite = { version = "0.27", default-features = false, features = ["handsha
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { version = "0.3", features = ["WebSocket", "CloseEvent", "ErrorEvent", "Event", "MessageEvent", "BinaryType"] }
-tokio = { version = "1", default-features = false, features = ["sync", "macros"] }
+tokio = { version = "1", default-features = false, features = ["sync", "macros", "io-util"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/src/native.rs
+++ b/src/native.rs
@@ -6,14 +6,20 @@ use crate::{
 };
 use reqwest::{
     header::{HeaderName, HeaderValue},
-    RequestBuilder, Response, StatusCode, Version,
+    Response, StatusCode, Version,
 };
 use tungstenite::protocol::WebSocketConfig;
+
+#[cfg(not(feature = "middleware"))]
+use reqwest::RequestBuilder;
+
+#[cfg(feature = "middleware")]
+use reqwest_middleware::RequestBuilder;
 
 pub async fn send_request(
     request_builder: RequestBuilder,
     protocols: &[String],
-) -> Result<WebSocketResponse, Error> {
+) -> anyhow::Result<WebSocketResponse> {
     let (client, request_result) = request_builder.build_split();
     let mut request = request_result?;
 
@@ -83,8 +89,7 @@ pub async fn send_request(
     })
 }
 
-pub type WebSocketStream =
-    async_tungstenite::WebSocketStream<tokio_util::compat::Compat<reqwest::Upgraded>>;
+pub type WebSocketStream = async_tungstenite::WebSocketStream<tokio_util::compat::Compat<reqwest::Upgraded>>;
 
 /// Error during `Websocket` handshake.
 #[derive(Debug, thiserror::Error)]


### PR DESCRIPTION
Hello,

Thank you for this great repository

I am using reqwest-websocket for the upcoming version of [ATAC](https://github.com/Julien-cpsn/ATAC) but I was missing reqwest-middlware support, so here the code proposal! I do think some other people may miss it too :)

Have a great day!

PS: regarding the TODO, currently there is no way to use the `http1_only` on reqwest-middleware client
PS2: also added anyhow for better error handling