### PR TITLE
Middleware feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reqwest-websocket"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 authors = ["Janosch Gräf <janosch.graef@gmail.com>"]
 description = "WebSocket connections with reqwest"
@@ -20,7 +20,10 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
+default = []
+full = ["json", "middleware"]
 json = ["dep:serde", "dep:serde_json"]
+middleware = ["dep:reqwest-middleware"]
 
 [dependencies]
 # pin version, see https://github.com/jgraef/reqwest-websocket/pull/33
@@ -35,6 +38,7 @@ serde_json = { version = "1.0", default-features = false, optional = true, featu
     "alloc",
 ] }
 bytes = "1.10.1"
+reqwest-middleware = { version = "0.5.0", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 async-tungstenite = { version = "0.32", default-features = false, features = [
@@ -68,6 +72,8 @@ futures-util = { version = "0.3", default-features = false, features = [
     "sink",
     "alloc",
 ] }
+async-trait = "0.1.89"
+http = "1.4.0"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Extension for [`reqwest`][2] to allow [websocket][1] connections.
 
-This crate contains the extension trait [`RequestBuilderExt`][4], which adds an
+This crate contains the extension trait [`Upgrade`][4], which adds an
 `upgrade` method to `reqwest::RequestBuilder` that prepares the HTTP request to
 upgrade the connection to a WebSocket. After you call `upgrade()`, you can send
 your upgraded request as usual with `send()`, which will return an
@@ -22,7 +22,7 @@ For a full example take a look at [`hello_world.rs`](examples/hello_world.rs).
 
 ```rust
 // Extends the `reqwest::RequestBuilder` to allow WebSocket upgrades.
-use reqwest_websocket::RequestBuilderExt;
+use reqwest_websocket::Upgrade;
 
 // Creates a GET request, upgrades and sends it.
 let response = Client::default()
@@ -56,4 +56,4 @@ request.
 [1]: https://en.wikipedia.org/wiki/WebSocket
 [2]: https://docs.rs/reqwest/latest/reqwest/index.html
 [3]: https://docs.rs/web-sys/latest/web_sys/struct.WebSocket.html
-[4]: https://docs.rs/reqwest-websocket/0.1.0/reqwest_websocket/trait.RequestBuilderExt.html
+[4]: https://docs.rs/reqwest-websocket/latest/reqwest_websocket/trait.Upgrade.html

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@ Document new features here. Document whether your changes are *breaking* semver-
  - Update `tungstenite` to 0.28
  - Update `async-tungstenite` to 0.32
  - tests: use local test server for native tests
+ - Add `Client` and `RequestBuilder` traits that abstract over the specific implementation of these types.
+   Rename `RequestBuilderExt` to `Upgrade`. `Upgrade` is a blanket extension for anything that implements our `RequestBuilder` trait.
+ - Add support for `request_middleware` behind `middleware` flag.
 
 # 0.5.1
 

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -1,6 +1,6 @@
 use futures_util::{SinkExt, StreamExt, TryStreamExt};
 use reqwest::Client;
-use reqwest_websocket::{Error, Message, RequestBuilderExt};
+use reqwest_websocket::{Error, Message, Upgrade};
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Error> {

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,0 +1,82 @@
+use crate::{Client, Error, RequestBuilder};
+
+impl Client for reqwest_middleware::ClientWithMiddleware {
+    async fn execute(&self, request: reqwest::Request) -> Result<reqwest::Response, Error> {
+        self.execute(request).await.map_err(Into::into)
+    }
+}
+
+impl RequestBuilder for reqwest_middleware::RequestBuilder {
+    type Client = reqwest_middleware::ClientWithMiddleware;
+
+    fn build_split(self) -> (Self::Client, Result<reqwest::Request, Error>) {
+        let (client, request) = reqwest_middleware::RequestBuilder::build_split(self);
+        (client, request.map_err(Into::into))
+    }
+}
+
+#[cfg(test)]
+#[cfg(not(target_arch = "wasm32"))]
+mod tests {
+    use crate::{
+        tests::{test_websocket, TestServer},
+        Upgrade,
+    };
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Debug)]
+    struct TestMiddleware {
+        did_run: Arc<Mutex<bool>>,
+    }
+
+    #[async_trait::async_trait]
+    impl reqwest_middleware::Middleware for TestMiddleware {
+        async fn handle(
+            &self,
+            req: reqwest::Request,
+            extensions: &mut http::Extensions,
+            next: reqwest_middleware::Next<'_>,
+        ) -> Result<reqwest::Response, reqwest_middleware::Error> {
+            {
+                let mut did_run = self.did_run.lock().unwrap();
+                *did_run = true;
+            }
+            next.run(req, extensions).await
+        }
+    }
+
+    //#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    //#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[tokio::test]
+    async fn websocket_with_middleware() {
+        let echo = TestServer::new().await;
+
+        let did_run = Arc::new(Mutex::new(false));
+        let middleware = TestMiddleware {
+            did_run: did_run.clone(),
+        };
+
+        let client = reqwest::Client::builder().http1_only().build().unwrap();
+        let client = reqwest_middleware::ClientBuilder::new(client)
+            .with(middleware)
+            .build();
+
+        let websocket = client
+            .get(echo.http_url())
+            .upgrade()
+            .send()
+            .await
+            .unwrap()
+            .into_websocket()
+            .await
+            .unwrap();
+
+        test_websocket(websocket).await;
+
+        let did_run = {
+            let did_run = did_run.lock().unwrap();
+            *did_run
+        };
+        assert!(did_run);
+    }
+}

--- a/src/native.rs
+++ b/src/native.rs
@@ -2,18 +2,21 @@ use std::borrow::Cow;
 
 use crate::{
     protocol::{CloseCode, Message},
-    Error,
+    Client, Error, RequestBuilder,
 };
 use reqwest::{
     header::{HeaderName, HeaderValue},
-    RequestBuilder, Response, StatusCode, Version,
+    Response, StatusCode, Version,
 };
 use tungstenite::protocol::WebSocketConfig;
 
-pub async fn send_request(
-    request_builder: RequestBuilder,
+pub async fn send_request<R>(
+    request_builder: R,
     protocols: &[String],
-) -> Result<WebSocketResponse, Error> {
+) -> Result<WebSocketResponse, Error>
+where
+    R: RequestBuilder,
+{
     let (client, request_result) = request_builder.build_split();
     let mut request = request_result?;
 


### PR DESCRIPTION
This addresses #52 

I've added traits `Client` and `RequestBuilder` that abstract over the specific implementation of a client and request builder - implemented by the corresponding `reqwest` and `reqwest_middleware` types.

We already has `RequestBuilderExt`, but it serves a different purpose. I renamed it to `Upgrade`, since that's the functionality it actually provides. I did think about this renaming in the past anyway, so this was a good time to do it.

The `Upgrade` extension trait will be implemented automatically for anything that is a `RequestBuilder`. It returns an `Upgraded<R> where R: RequestBuilder` that then is generic, but has all the information to perform the websocket upgrade.

All the `middleware` feature then has to do, is to implement the `Client` and `ClientBuilder` traits for `reqwest_middleware::ClientWithMiddleware` and `reqwest_middleware::RequestBuilder` respectively. 

Because of the new traits and renamings, this will require a minor version bump.

There's one test for the `middleware` feature right now, but it doesn't work on wasm. The `middleware` feature does compile for wasm, but we should make sure it's actually usable.