### PR TITLE
Ability to build requests before executing them

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,6 +247,34 @@ where
             web_socket_config: self.web_socket_config,
         })
     }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn build_split(self) -> Result<(Upgraded<R::Client>, reqwest::Request), Error> {
+        let (client, request_result) = self.inner.build_split();
+        let request = request_result?;
+        let client = Upgraded {
+            inner: client,
+            protocols: self.protocols,
+            web_socket_config: self.web_socket_config,
+        };
+        Ok((client, request))
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl<C> Upgraded<C>
+where
+    C: Client,
+{
+    pub async fn execute(self, request: reqwest::Request) -> Result<UpgradeResponse, Error> {
+        let inner = native::execute(self.inner, request, &self.protocols).await?;
+
+        Ok(UpgradeResponse {
+            inner,
+            protocols: self.protocols,
+            web_socket_config: self.web_socket_config,
+        })
+    }
 }
 
 /// The server's response to the `WebSocket` upgrade request.

--- a/src/native.rs
+++ b/src/native.rs
@@ -18,8 +18,19 @@ where
     R: RequestBuilder,
 {
     let (client, request_result) = request_builder.build_split();
-    let mut request = request_result?;
+    let request = request_result?;
 
+    execute::<R::Client>(client, request, protocols).await
+}
+
+pub async fn execute<C>(
+    client: C,
+    mut request: reqwest::Request,
+    protocols: &[String],
+) -> Result<WebSocketResponse, Error>
+where
+    C: Client,
+{
     // change the scheme from wss? to https?
     let url = request.url_mut();
     match url.scheme() {


### PR DESCRIPTION
Hey, this is just a first pass at adding ability to build a request for introspection before sending it.

My use case is that I use request signing in my app by reading the request properties to create the signature, then appending it to the headers.

I gated it behind the native architecture as it seems like wasm doesn't really have an idea of client, but let me know if you want it added to wasm as well.